### PR TITLE
Fix fetch header merging

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,8 @@ const fetchGithubApp = config => {
       fetchJson(
         getGithubApiUrl(path),
         Object.assign(
+          {},
+          request,
           {
             headers: Object.assign(
               getApiRequestHeaders({
@@ -97,8 +99,7 @@ const fetchGithubApp = config => {
               }),
               request.headers || {}
             ),
-          },
-          request
+          }
         )
       );
 


### PR DESCRIPTION
This will allow to add headers while keep adding the headers needed to authenticate on the github endpoints